### PR TITLE
Bug Fix: Update state before unmounting

### DIFF
--- a/src/AdaptivePopover.tsx
+++ b/src/AdaptivePopover.tsx
@@ -277,8 +277,9 @@ export default class AdaptivePopover extends Component<AdaptivePopoverProps, Ada
           if (this._isMounted) this.setState({ shiftedDisplayArea: null });
         }}
         onCloseComplete={() => {
-          if (onCloseComplete) onCloseComplete();
-          this.setState({ showing: false });
+          this.setState({ showing: false }, () => {
+            if (onCloseComplete) onCloseComplete();
+          });
         }}
         skipMeasureContent={() => this.waitForResizeToFinish}
         onDisplayAreaChanged={rect => this.setDefaultDisplayArea(rect)}


### PR DESCRIPTION
## Issue Number

[Issue 69](https://github.com/SteffeyDev/react-native-popover-view/issues/69)

## Overview

While closing a `<Popover />`, I got the warning `Can't perform a react state updated on an unmounted component.`. Updating the state to set `showing: false` first then triggering the `onCloseComplete` function solved this issue.

## Task List

* [x] move `onCloseComplete` to `setState` callback function

## Visual

<img src="https://user-images.githubusercontent.com/9324607/173131374-b346260e-3aa4-4224-b2d8-35599113b637.png" width="500" alt="unmount-component-bug" />
